### PR TITLE
Fix/api update

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,11 @@ jobs:
       - name: Run tests and generate coverage report
         run: |
           ./gradlew clean test --tests "io.github.Toku2001.trackandfieldapp.unittest.competition.CompetitionControllerTest"
-          ./gradlew test --tests "io.github.Toku2001.trackandfieldapp.unittest.competition.CompetitionServiceImplTest"
+          ./gradlew test \
+          --tests "io.github.Toku2001.trackandfieldapp.unittest.competition.CompetitionServiceImplTest" \
+          --tests "io.github.Toku2001.trackandfieldapp.unittest.competition.CompetitionControllerTest" \
+          --tests "io.github.Toku2001.trackandfieldapp.AuthController" \
+          --tests "io.github.Toku2001.trackandfieldapp.TrainingTest"
           ./gradlew jacocoTestReport
         env:
           POSTGRES_DB: ${{ secrets.DB_NAME }}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/controller/ChangeController.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/controller/ChangeController.java
@@ -1,5 +1,6 @@
 package io.github.Toku2001.trackandfieldapp.controller;
 
+import java.util.List;
 import java.util.Map;
 
 import jakarta.validation.Valid;
@@ -14,9 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
 import io.github.Toku2001.trackandfieldapp.dto.competition.ChangeCompetitionRequest;
+import io.github.Toku2001.trackandfieldapp.dto.jump.ChangeJumpRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.ChangeTrainingRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.ChangeTrainingResponse;
 import io.github.Toku2001.trackandfieldapp.service.competition.ChangeCompetitionService;
+import io.github.Toku2001.trackandfieldapp.service.jump.ChangeJumpService;
 import io.github.Toku2001.trackandfieldapp.service.training.ChangeTrainingService;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +29,7 @@ import lombok.RequiredArgsConstructor;
 public class ChangeController {
     private final ChangeTrainingService changeTrainingSerivice;
     private final ChangeCompetitionService changeCompetitionService;
+    private final ChangeJumpService changeJumpService;
     
     @PutMapping("/change-training")
     public ResponseEntity<?> changeTraining(@Valid @RequestBody ChangeTrainingRequest request, BindingResult bindingResult){
@@ -49,5 +53,14 @@ public class ChangeController {
 			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid credentials");
 		}
         return changeCompetitionNumber;
+    }
+    
+    @PutMapping("/change-jump-records")
+    public int changeJumpRecord(@RequestBody List<ChangeJumpRequest> request){
+        int changeJumpNumber = changeJumpService.changeJump(request);
+        if(changeJumpNumber == 0) {
+			throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid credentials");
+		}
+        return changeJumpNumber;
     }
 }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/controller/DeleteController.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/controller/DeleteController.java
@@ -1,22 +1,19 @@
 package io.github.Toku2001.trackandfieldapp.controller;
 
-import java.util.Map;
+import java.time.LocalDate;
 
-import jakarta.validation.Valid;
-
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import io.github.Toku2001.trackandfieldapp.dto.competition.DeleteCompetitionRequest;
-import io.github.Toku2001.trackandfieldapp.dto.training.DeleteTrainingRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.DeleteTrainingResponse;
 import io.github.Toku2001.trackandfieldapp.service.competition.DeleteCompetitionService;
+import io.github.Toku2001.trackandfieldapp.service.jump.DeleteJumpService;
 import io.github.Toku2001.trackandfieldapp.service.training.DeleteTrainingService;
 import lombok.RequiredArgsConstructor;
 
@@ -26,30 +23,46 @@ import lombok.RequiredArgsConstructor;
 public class DeleteController {
 	private final DeleteTrainingService deleteTrainingService;
 	private final DeleteCompetitionService deleteCompetitionService;
+	private final DeleteJumpService deleteJumpService;
     
     @DeleteMapping("/delete-training")
-    public ResponseEntity<?> deleteTraining(@Valid @RequestBody DeleteTrainingRequest request, BindingResult bindingResult){
-    	if (bindingResult.hasErrors()) {
-            // 最初のエラーメッセージを取得して返す例
-            String errorMsg = bindingResult.getAllErrors().get(0).getDefaultMessage();
-            return ResponseEntity.badRequest().body(Map.of("error", errorMsg));
-        }
-    	int deleteTrainingNumber = deleteTrainingService.deleteTraining(request); {
+    public ResponseEntity<?> deleteTraining(@RequestParam("trainingDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate trainingDate){
+    	int deleteTrainingNumber = deleteTrainingService.deleteTraining(trainingDate); {
         if (deleteTrainingNumber == 0) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials");
         }
-        return ResponseEntity.ok(new DeleteTrainingResponse(request.getTrainingDate(), deleteTrainingNumber));
+        return ResponseEntity.ok(new DeleteTrainingResponse(trainingDate, deleteTrainingNumber));
     	}
     }
     
     @DeleteMapping("/delete-competition")
-    public int deleteCompetition(@RequestBody DeleteCompetitionRequest request){
-    	int deleteCompetitionNumber = deleteCompetitionService.deleteCompetition(request); {
+    public int deleteCompetition(@RequestParam("competitionDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate competitionDate){
+    	int deleteCompetitionNumber = deleteCompetitionService.deleteCompetition(competitionDate); {
         if (deleteCompetitionNumber == 0) {
             System.out.println("deleteCompetition failed: training not found");
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid credentials");
         }
         return deleteCompetitionNumber;
     	}
+    }
+    
+    @DeleteMapping("/delete-jump-record")
+    public ResponseEntity<Void> deleteById(@RequestParam Long jumpEventId) {
+    	int deletedCount = deleteJumpService.deleteById(jumpEventId);
+        if (deletedCount > 0) {
+            return ResponseEntity.noContent().build(); // 204 No Content：正常削除
+        } else {
+            return ResponseEntity.notFound().build(); // 404 Not Found：対象が存在しなかった
+        }
+    }
+    
+    @DeleteMapping("/delete-jump-records-by-date")
+    public ResponseEntity<Void> deleteByDate(@RequestParam String jumpDate) {
+    	int deletedCount = deleteJumpService.deleteAllByDate(jumpDate);
+        if (deletedCount > 0) {
+            return ResponseEntity.noContent().build(); // 204 No Content：正常削除
+        } else {
+            return ResponseEntity.notFound().build(); // 404 Not Found：対象が存在しなかった
+        }
     }
 }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/controller/ReadController.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/controller/ReadController.java
@@ -1,17 +1,22 @@
 package io.github.Toku2001.trackandfieldapp.controller;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.github.Toku2001.trackandfieldapp.dto.competition.CompetitionResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.JumpResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.PersonalBestResponse;
 import io.github.Toku2001.trackandfieldapp.dto.training.TrainingResponse;
 import io.github.Toku2001.trackandfieldapp.exception.DatabaseOperationException;
 import io.github.Toku2001.trackandfieldapp.service.competition.CompetitionService;
+import io.github.Toku2001.trackandfieldapp.service.jump.JumpService;
 import io.github.Toku2001.trackandfieldapp.service.training.TrainingService;
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class ReadController {
 	private final TrainingService trainingService;
 	private final CompetitionService competitionService;
+	private final JumpService jumpService;
 	
 	@GetMapping("/get-training")
 	public TrainingResponse readTraining(@RequestParam("trainingDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate trainingDate) {
@@ -36,6 +42,13 @@ public class ReadController {
 		return competitionResponse;
 	}
 	
+	@GetMapping("/get-jump-records")
+    public ResponseEntity<List<JumpResponse>> getJumpRecords(@RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate jumpDate) {
+		System.out.println("リクエストで送られてきた日時は"+jumpDate);
+        List<JumpResponse> records = jumpService.getJumpRecords(jumpDate);
+        return ResponseEntity.ok(records);
+    }
+	
 	@GetMapping("/get-competition-upcoming")
 	public CompetitionResponse getNextCompetition() {
 		CompetitionResponse competitionResponse = competitionService.getNextCompetition();
@@ -43,5 +56,14 @@ public class ReadController {
         	throw new DatabaseOperationException("コントローラにデータが届いていません。");
         }
 		return competitionResponse;
+	}
+	
+	@GetMapping("/get-personal-best")
+	public List<PersonalBestResponse> getPersonalBest() {
+		List<PersonalBestResponse> personalBestResponse = jumpService.getPersonalBest();
+        if(personalBestResponse == null) {
+        	throw new DatabaseOperationException("コントローラにデータが届いていません。");
+        }
+		return personalBestResponse;
 	}
 }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/controller/RegisterController.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/controller/RegisterController.java
@@ -1,6 +1,7 @@
 package io.github.Toku2001.trackandfieldapp.controller;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import jakarta.validation.Valid;
@@ -13,8 +14,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.github.Toku2001.trackandfieldapp.dto.competition.RegisterCompetitionRequest;
+import io.github.Toku2001.trackandfieldapp.dto.jump.RegisterJumpRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.RegisterTrainingRequest;
 import io.github.Toku2001.trackandfieldapp.service.competition.RegisterCompetitionService;
+import io.github.Toku2001.trackandfieldapp.service.jump.RegisterJumpService;
 import io.github.Toku2001.trackandfieldapp.service.training.RegisterTrainingService;
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 public class RegisterController {
 	private final RegisterTrainingService registerTrainingService;
 	private final RegisterCompetitionService registerCompetitionService;
+	private final RegisterJumpService registerJumpService;
 	
 	@PostMapping("/register-training")
 	public ResponseEntity<Map<String, Object>> registerTraining(@Valid @RequestBody RegisterTrainingRequest request, BindingResult bindingResult) {
@@ -32,10 +36,14 @@ public class RegisterController {
             String errorMsg = bindingResult.getAllErrors().get(0).getDefaultMessage();
             return ResponseEntity.badRequest().body(Map.of("error", errorMsg));
         }
-		int registerNumber = registerTrainingService.registerTraining(request);
-		Map<String, Object> response = new HashMap<>();
-    	response.put("result", registerNumber);
-		return ResponseEntity.ok(response);
+		try {
+			int registerNumber = registerTrainingService.registerTraining(request);
+			Map<String, Object> response = new HashMap<>();
+	    	response.put("result", registerNumber);
+			return ResponseEntity.ok(response);
+	    } catch (IllegalStateException e) {
+	        return ResponseEntity.status(409).body(Map.of("error", e.getMessage())); // 409 Conflict
+	    }
 	}
 	
 	@PostMapping("/register-competition")
@@ -45,7 +53,17 @@ public class RegisterController {
             String errorMsg = bindingResult.getAllErrors().get(0).getDefaultMessage();
             return ResponseEntity.badRequest().body(Map.of("error", errorMsg));
         }
-		int registerCompetitionNumber = registerCompetitionService.registerCompetition(request);
-		return ResponseEntity.ok(registerCompetitionNumber);
+		try {
+	        int result = registerCompetitionService.registerCompetition(request);
+	        return ResponseEntity.ok(result);
+	    } catch (IllegalStateException e) {
+	        return ResponseEntity.status(409).body(Map.of("error", e.getMessage())); // 409 Conflict
+	    }
 	}
+	
+	@PostMapping("/register-jump-records")
+    public ResponseEntity<?> registerJumpRecords(@RequestBody List<RegisterJumpRequest> records) {
+    	registerJumpService.registerJump(records);
+    	return ResponseEntity.ok(Map.of("result", 1));
+    }
 }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/competition/ChangeCompetitionRequest.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/competition/ChangeCompetitionRequest.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor 
 public class ChangeCompetitionRequest {
+	private int competitionId;
     private String competitionName;
     private String competitionPlace;
     private LocalDate competitionTime;

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/competition/CompetitionResponse.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/competition/CompetitionResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor 
 public class CompetitionResponse {
+	private int competitionId;
     private String competitionName;
     private String competitionPlace;
     private LocalDate competitionTime;

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/jump/ChangeJumpRequest.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/jump/ChangeJumpRequest.java
@@ -1,0 +1,21 @@
+package io.github.Toku2001.trackandfieldapp.dto.jump;
+
+import java.time.LocalDate;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangeJumpRequest {
+	private long jumpEventId;
+    private String event;         // 種目（例: pole_vault）
+    private double distance;      // 記録（メートル）
+    private int approach;         // 助走の歩数
+    private String poleFeat;      // ポールの長さ（例: "4.80"）
+    private String polePond;      // ポールの硬さ（例: "170"）
+    private String recordType;    // 記録の種別（training / competition）
+    private LocalDate jumpDate;      // 記録日（例: "2025-08-02"）
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/jump/JumpResponse.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/jump/JumpResponse.java
@@ -1,0 +1,19 @@
+package io.github.Toku2001.trackandfieldapp.dto.jump;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class JumpResponse {
+	private long jumpEventId;
+    private String event;
+    private Double distance;
+    private Integer approach;
+    private String poleFeat;
+    private String polePond;
+    private String recordType;
+    private String jumpDate;  // yyyy-MM-dd
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/jump/PersonalBestResponse.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/jump/PersonalBestResponse.java
@@ -1,0 +1,14 @@
+package io.github.Toku2001.trackandfieldapp.dto.jump;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PersonalBestResponse {
+    private String event;
+    private Double distance;
+    private String jumpDate;
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/jump/RegisterJumpRequest.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/jump/RegisterJumpRequest.java
@@ -1,0 +1,30 @@
+package io.github.Toku2001.trackandfieldapp.dto.jump;
+
+
+
+import java.time.LocalDate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RegisterJumpRequest {
+
+    @NotBlank(message = "種目名は必須です")
+    private String event; //種目
+    @NotNull(message = "記録は必須です")
+    private Double distance; //記録
+    @NotNull(message = "助走歩数は必須です")
+    private Integer approach; //助走歩数
+    private String poleFeat; // 例: 4.60
+    private String polePond; // 例: 160
+    private String recordType; //練習・競技会
+    private LocalDate jumpDate;
+
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/training/ChangeTrainingRequest.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/training/ChangeTrainingRequest.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor 
 public class ChangeTrainingRequest {
+	private int trainingId;
 	@NotNull(message = "更新したい練習日誌の日付が正しくリクエストされていません")
     private LocalDate trainingTime;
     private String trainingPlace;

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/training/TrainingRequest.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/training/TrainingRequest.java
@@ -1,0 +1,19 @@
+package io.github.Toku2001.trackandfieldapp.dto.training;
+
+
+
+import java.util.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor 
+public class TrainingRequest {
+    private Date trainingTime;
+    private String trainingPlace;
+    private String trainingComments;
+//    private JumpRecordRequestDto jumpRecord;
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/dto/training/TrainingResponse.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/dto/training/TrainingResponse.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor 
 public class TrainingResponse {
+	private int trainingId;
     private LocalDate trainingTime;
     private String trainingPlace;
     private String trainingComments;

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/entity/Competition_Info.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/entity/Competition_Info.java
@@ -10,8 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Competition_Info {
-    private long competition_Id;
-    private long user_Id;
+    private Integer competition_Id;
     private String competition_Name;
     private String competition_Place;
     private LocalDate competition_Time;

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/entity/Jump_Events.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/entity/Jump_Events.java
@@ -1,0 +1,24 @@
+package io.github.Toku2001.trackandfieldapp.entity;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Jump_Events {
+	private Long jump_event_id;
+    private Long user_id;
+    private String event_code;
+    private Double jump_distance;
+    private Integer approach_steps;
+    private String pole_length;
+    private String pole_stiffness;
+    private String record_type;
+    private LocalDate jump_date;
+    private LocalDateTime insert_date;
+    private LocalDateTime update_date;
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/entity/Training_Info.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/entity/Training_Info.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Training_Info {
+	private Integer training_Id;
     private Integer user_Id;
     private LocalDate training_Time;
     private String training_Place;

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/repository/CompetitionMapper.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/repository/CompetitionMapper.java
@@ -1,7 +1,6 @@
 package io.github.Toku2001.trackandfieldapp.repository;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -32,11 +31,12 @@ public interface CompetitionMapper {
     // );
     
     // 近日開催の競技会情報を取得
-    Competition_Info getNextCompetition();
+    Competition_Info getNextCompetition(@Param("userId") long userId);
 
     // 大会情報の更新（日時とユーザーIDで対象を特定）
     int changeCompetition(
         @Param("userId") long userId,
+        @Param("competitionId") int competitionId,
         @Param("competitionName") String competitionName,
         @Param("competitionPlace") String competitionPlace,
         @Param("competitionTime") LocalDate competitionTime,

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/repository/JumpMapper.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/repository/JumpMapper.java
@@ -19,7 +19,7 @@ public interface JumpMapper {
 	List<Jump_Events> getJumpRecord(@Param("userId") Long userId, @Param("date") LocalDate date);
 	
 	// 跳躍記録の更新
-	void changeJump(@Param("userId") long userId, @Param("event") ChangeJumpRequest event);
+	int changeJump(@Param("userId") long userId, @Param("event") ChangeJumpRequest event);
 	
 	//跳躍記録の一部削除
 	int deleteById(@Param("jumpEventId") Long jumpEventId);

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/repository/JumpMapper.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/repository/JumpMapper.java
@@ -1,0 +1,32 @@
+package io.github.Toku2001.trackandfieldapp.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import io.github.Toku2001.trackandfieldapp.dto.jump.ChangeJumpRequest;
+import io.github.Toku2001.trackandfieldapp.dto.jump.RegisterJumpRequest;
+import io.github.Toku2001.trackandfieldapp.entity.Jump_Events;
+
+@Mapper
+public interface JumpMapper {
+    // 跳躍記録の登録
+	int registerJump(@Param("userId") long userId, @Param("event") RegisterJumpRequest event);
+	
+	//跳躍記録の取得
+	List<Jump_Events> getJumpRecord(@Param("userId") Long userId, @Param("date") LocalDate date);
+	
+	// 跳躍記録の更新
+	void changeJump(@Param("userId") long userId, @Param("event") ChangeJumpRequest event);
+	
+	//跳躍記録の一部削除
+	int deleteById(@Param("jumpEventId") Long jumpEventId);
+	
+	//跳躍記録の全削除
+	int deleteAllByDate(@Param("jumpDate") LocalDate jumpDate);
+	
+	//自己ベスト取得
+	List<Jump_Events> getPersonalBest(@Param("userId") long userId);
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/repository/TrainingMapper.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/repository/TrainingMapper.java
@@ -1,7 +1,6 @@
 package io.github.Toku2001.trackandfieldapp.repository;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -30,6 +29,7 @@ public interface TrainingMapper {
     //練習日誌編集
 	 int changeTraining(
 		@Param("userId") long userId,
+		@Param("trainingId") int trainingId,
 		@Param("trainingTime") LocalDate trainingTime,
 		@Param("trainingPlace") String trainingPlace,
 		@Param("trainingComments") String trainingComments

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/security/SecurityConfig.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/security/SecurityConfig.java
@@ -26,7 +26,18 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**").permitAll()
+                .requestMatchers(
+                	"/auth/**",
+                	"/config.js",
+                    "/login/**",
+                    "/home/**",
+                    "/daily/**",
+                    "/jump/**",
+                    "/passwordReset/**",
+                    "/tournament/**",
+                    "/training/**",
+                    "/userCreate/**"
+                ).permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/DeleteCompetitionService.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/DeleteCompetitionService.java
@@ -1,7 +1,7 @@
 package io.github.Toku2001.trackandfieldapp.service.competition;
 
-import io.github.Toku2001.trackandfieldapp.dto.competition.DeleteCompetitionRequest;
+import java.time.LocalDate;
 
 public interface DeleteCompetitionService{
-	int deleteCompetition(DeleteCompetitionRequest request);
+	int deleteCompetition(LocalDate competitionDate);
 }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/impl/ChangeCompetitionServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/impl/ChangeCompetitionServiceImpl.java
@@ -23,6 +23,7 @@ public class ChangeCompetitionServiceImpl implements ChangeCompetitionService{
 	    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
 	    int updateCompetitionNumber = competitionMapper.changeCompetition(userDetails.getUserId(),
+	    															  request.getCompetitionId(),
 	    															  request.getCompetitionName(),
 																	  request.getCompetitionPlace(),
 																	  request.getCompetitionTime(),

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/impl/CompetitionServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/impl/CompetitionServiceImpl.java
@@ -33,6 +33,7 @@ public class CompetitionServiceImpl implements CompetitionService{
             throw new DatabaseOperationException("想定のデータが取得できていません。", new Exception());
         }
         CompetitionResponse competitionResponse = new CompetitionResponse();
+        competitionResponse.setCompetitionId(competition_Info.getCompetition_Id());
         competitionResponse.setCompetitionName(competition_Info.getCompetition_Name());
         competitionResponse.setCompetitionPlace(competition_Info.getCompetition_Place());
         competitionResponse.setCompetitionTime(competition_Info.getCompetition_Time());
@@ -42,7 +43,9 @@ public class CompetitionServiceImpl implements CompetitionService{
 	
 	@Override
 	public CompetitionResponse getNextCompetition() {
-		Competition_Info competition_Info = competitionMapper.getNextCompetition();
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
+		Competition_Info competition_Info = competitionMapper.getNextCompetition(userDetails.getUserId());
         if (competition_Info == null) {
         	throw new DatabaseOperationException("想定のデータが取得できていません。", new Exception());
         }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/impl/DeleteCompetitionServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/impl/DeleteCompetitionServiceImpl.java
@@ -1,12 +1,13 @@
 package io.github.Toku2001.trackandfieldapp.service.competition.impl;
 
+import java.time.LocalDate;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.github.Toku2001.trackandfieldapp.dto.competition.DeleteCompetitionRequest;
 import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
 import io.github.Toku2001.trackandfieldapp.exception.DatabaseOperationException;
 import io.github.Toku2001.trackandfieldapp.repository.CompetitionMapper;
@@ -21,11 +22,11 @@ public class DeleteCompetitionServiceImpl implements DeleteCompetitionService{
 	private final CompetitionMapper competitionMapper;
 	
 	@Override
-    public int deleteCompetition(DeleteCompetitionRequest request) {
-		System.out.println("DeleteUserService received: " + request.getCompetitionDate());
+    public int deleteCompetition(LocalDate competitionDate) {
+		System.out.println("DeleteUserService received: " + competitionDate);
 	    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
-	    int deleteCompetitionNumber = competitionMapper.deleteCompetition(userDetails.getUserId(), request.getCompetitionDate());
+	    int deleteCompetitionNumber = competitionMapper.deleteCompetition(userDetails.getUserId(), competitionDate);
         if (deleteCompetitionNumber == 0) {
             throw new DatabaseOperationException("正しく競技会情報が削除されませんでした", new Exception());
         }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/impl/RegisterCompetitionServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/competition/impl/RegisterCompetitionServiceImpl.java
@@ -1,5 +1,6 @@
 package io.github.Toku2001.trackandfieldapp.service.competition.impl;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -22,14 +23,18 @@ public class RegisterCompetitionServiceImpl implements RegisterCompetitionServic
     public int registerCompetition(RegisterCompetitionRequest request) {
 	    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
-        int registerNumber = competitionMapper.registerCompetition(userDetails.getUserId(),
-        													 request.getCompetitionName(),
-        													 request.getCompetitionPlace(),
-        													 request.getCompetitionTime(),
-        													 request.getCompetitionComments());
-        if (registerNumber == 0) {
-            throw new DatabaseOperationException("練習日誌を登録できませんでした", new Exception());
-        }
-        return registerNumber;
-    }
+	    try {
+	    	int registerNumber = competitionMapper.registerCompetition(userDetails.getUserId(),
+					 request.getCompetitionName(),
+					 request.getCompetitionPlace(),
+					 request.getCompetitionTime(),
+					 request.getCompetitionComments());
+			if (registerNumber == 0) {
+				throw new DatabaseOperationException("練習日誌を登録できませんでした", new Exception());
+			}
+			return registerNumber;
+	    }catch (DataIntegrityViolationException e) {
+	         throw new IllegalStateException("この日付の大会は既に登録されています。");
+	    }
+	}
 }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/ChangeJumpService.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/ChangeJumpService.java
@@ -1,0 +1,10 @@
+package io.github.Toku2001.trackandfieldapp.service.jump;
+
+import java.util.List;
+
+import io.github.Toku2001.trackandfieldapp.dto.jump.ChangeJumpRequest;
+
+public interface ChangeJumpService {
+	//跳躍記録の更新
+	int changeJump(List<ChangeJumpRequest> changeJumpRequest);
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/DeleteJumpService.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/DeleteJumpService.java
@@ -1,0 +1,9 @@
+package io.github.Toku2001.trackandfieldapp.service.jump;
+
+public interface DeleteJumpService {
+	// 指定した跳躍記録を削除する
+	int deleteById(Long jumpEventId);
+	
+	// 指定された日の跳躍記録を全て削除する
+	int deleteAllByDate(String jumpDate);
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/JumpService.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/JumpService.java
@@ -1,0 +1,13 @@
+package io.github.Toku2001.trackandfieldapp.service.jump;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import io.github.Toku2001.trackandfieldapp.dto.jump.JumpResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.PersonalBestResponse;
+
+public interface JumpService {
+    List<JumpResponse> getJumpRecords(LocalDate date);
+    
+    List<PersonalBestResponse> getPersonalBest();
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/RegisterJumpService.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/RegisterJumpService.java
@@ -1,0 +1,10 @@
+package io.github.Toku2001.trackandfieldapp.service.jump;
+
+import java.util.List;
+
+import io.github.Toku2001.trackandfieldapp.dto.jump.RegisterJumpRequest;
+
+public interface RegisterJumpService {
+	//跳躍記録の登録
+	void registerJump(List<RegisterJumpRequest> registerEventRequest);
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/ChangeJumpServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/ChangeJumpServiceImpl.java
@@ -1,0 +1,44 @@
+package io.github.Toku2001.trackandfieldapp.service.jump.impl;
+
+import java.util.List;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.Toku2001.trackandfieldapp.dto.jump.ChangeJumpRequest;
+import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
+import io.github.Toku2001.trackandfieldapp.exception.DatabaseOperationException;
+import io.github.Toku2001.trackandfieldapp.repository.JumpMapper;
+import io.github.Toku2001.trackandfieldapp.service.jump.ChangeJumpService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChangeJumpServiceImpl implements ChangeJumpService{
+
+	private final JumpMapper jumpMapper;
+	
+	@Override
+	public int changeJump(List<ChangeJumpRequest> changeJumpRequest){
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
+	    long userId = userDetails.getUserId();
+	    //更新レコード
+	    int changeJumpRecordNumber = 0;
+	    try {
+			for(ChangeJumpRequest target : changeJumpRequest) {
+				jumpMapper.changeJump(userId, target);
+				changeJumpRecordNumber++;
+			}
+			if(changeJumpRecordNumber == changeJumpRequest.size()) {
+				return 1;
+			}
+	    }catch(DatabaseOperationException e) {
+	    	throw new DatabaseOperationException("跳躍情報の更新件数が0件です。", new Exception());
+	    }
+		return 0;
+	}
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/ChangeJumpServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/ChangeJumpServiceImpl.java
@@ -30,8 +30,8 @@ public class ChangeJumpServiceImpl implements ChangeJumpService{
 	    int changeJumpRecordNumber = 0;
 	    try {
 			for(ChangeJumpRequest target : changeJumpRequest) {
-				jumpMapper.changeJump(userId, target);
-				changeJumpRecordNumber++;
+				int updatedCount = jumpMapper.changeJump(userId, target);
+            	changeJumpRecordNumber += updatedCount;
 			}
 			if(changeJumpRecordNumber == changeJumpRequest.size()) {
 				return 1;

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/DeleteJumpServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/DeleteJumpServiceImpl.java
@@ -1,0 +1,28 @@
+package io.github.Toku2001.trackandfieldapp.service.jump.impl;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.Toku2001.trackandfieldapp.repository.JumpMapper;
+import io.github.Toku2001.trackandfieldapp.service.jump.DeleteJumpService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeleteJumpServiceImpl implements DeleteJumpService {
+	
+	private final JumpMapper jumpMapper;
+	// 指定した跳躍記録を削除する
+	public int deleteById(Long jumpEventId) {
+		return jumpMapper.deleteById(jumpEventId);
+	}
+	
+	// 指定された日の跳躍記録を全て削除する
+	public int deleteAllByDate(String jumpDate) {
+		LocalDate selectDate = LocalDate.parse(jumpDate);
+		return jumpMapper.deleteAllByDate(selectDate);
+	}
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/JumpServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/JumpServiceImpl.java
@@ -1,0 +1,56 @@
+package io.github.Toku2001.trackandfieldapp.service.jump.impl;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.Toku2001.trackandfieldapp.dto.jump.JumpResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.PersonalBestResponse;
+import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
+import io.github.Toku2001.trackandfieldapp.entity.Jump_Events;
+import io.github.Toku2001.trackandfieldapp.repository.JumpMapper;
+import io.github.Toku2001.trackandfieldapp.service.jump.JumpService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class JumpServiceImpl implements JumpService {
+
+    private final JumpMapper jumpMapper;
+
+    @Override
+    public List<JumpResponse> getJumpRecords(LocalDate date) {
+    	Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
+        List<Jump_Events> events = jumpMapper.getJumpRecord(userDetails.getUserId(), date);
+        return events.stream().map(e -> new JumpResponse(
+        		e.getJump_event_id(),
+                e.getEvent_code(),
+                e.getJump_distance(),
+                e.getApproach_steps(),
+                e.getPole_length(),
+                e.getPole_stiffness(),
+                e.getRecord_type(),
+                e.getJump_date().format(DateTimeFormatter.ISO_DATE)
+        )).collect(Collectors.toList());
+    }
+    
+    @Override
+    public List<PersonalBestResponse> getPersonalBest(){
+    	Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
+	    List<Jump_Events> personalBest = jumpMapper.getPersonalBest(userDetails.getUserId());
+	    return personalBest.stream().map(e -> new PersonalBestResponse(
+                e.getEvent_code(),
+                e.getJump_distance(),
+                e.getJump_date().format(DateTimeFormatter.ISO_DATE)
+        )).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/RegisterJumpServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/jump/impl/RegisterJumpServiceImpl.java
@@ -1,0 +1,33 @@
+package io.github.Toku2001.trackandfieldapp.service.jump.impl;
+
+import java.util.List;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.Toku2001.trackandfieldapp.dto.jump.RegisterJumpRequest;
+import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
+import io.github.Toku2001.trackandfieldapp.repository.JumpMapper;
+import io.github.Toku2001.trackandfieldapp.service.jump.RegisterJumpService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RegisterJumpServiceImpl implements RegisterJumpService{
+
+	private final JumpMapper jumpMapper;
+	
+	@Override
+	public void registerJump(List<RegisterJumpRequest> registerJumpRequest){
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
+	    long userId = userDetails.getUserId();
+	    
+		for(RegisterJumpRequest target : registerJumpRequest) {
+			jumpMapper.registerJump(userId, target);
+		}
+	}
+}

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/DeleteTrainingService.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/DeleteTrainingService.java
@@ -1,7 +1,7 @@
 package io.github.Toku2001.trackandfieldapp.service.training;
 
-import io.github.Toku2001.trackandfieldapp.dto.training.DeleteTrainingRequest;
+import java.time.LocalDate;
 
 public interface DeleteTrainingService{
-	int deleteTraining(DeleteTrainingRequest request);
+	int deleteTraining(LocalDate trainingDate);
 }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/impl/ChangeTrainingServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/impl/ChangeTrainingServiceImpl.java
@@ -25,6 +25,7 @@ public class ChangeTrainingServiceImpl implements ChangeTrainingService{
 	    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
 	    int updateTrainingNumber = trainingMapper.changeTraining(userDetails.getUserId(),
+	    		 request.getTrainingId(),
 				 request.getTrainingTime(),
 				 request.getTrainingPlace(),
 				 request.getTrainingComments());

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/impl/DeleteTrainingServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/impl/DeleteTrainingServiceImpl.java
@@ -1,12 +1,13 @@
 package io.github.Toku2001.trackandfieldapp.service.training.impl;
 
+import java.time.LocalDate;
+
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.github.Toku2001.trackandfieldapp.dto.training.DeleteTrainingRequest;
 import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
 import io.github.Toku2001.trackandfieldapp.exception.DatabaseOperationException;
 import io.github.Toku2001.trackandfieldapp.repository.TrainingMapper;
@@ -21,11 +22,11 @@ public class DeleteTrainingServiceImpl implements DeleteTrainingService{
 	private final TrainingMapper trainingMapper;
 	
 	@Override
-    public int deleteTraining(DeleteTrainingRequest request) {
-		System.out.println("DeleteUserService received: " + request.getTrainingDate());
+    public int deleteTraining(LocalDate trainingDate) {
+		System.out.println("DeleteUserService received: " + trainingDate);
 	    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
-	    int deleteTrainingNumber = trainingMapper.deleteTraining(userDetails.getUserId(), request.getTrainingDate());
+	    int deleteTrainingNumber = trainingMapper.deleteTraining(userDetails.getUserId(), trainingDate);
         if (deleteTrainingNumber == 0) {
             throw new DatabaseOperationException("正しく練習日誌が削除されませんでした", new Exception());
         }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/impl/RegisterTrainingServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/impl/RegisterTrainingServiceImpl.java
@@ -1,5 +1,6 @@
 package io.github.Toku2001.trackandfieldapp.service.training.impl;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -22,13 +23,17 @@ public class RegisterTrainingServiceImpl implements RegisterTrainingService{
     public int registerTraining(RegisterTrainingRequest request) {
 	    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 	    UserDetailsForToken userDetails = (UserDetailsForToken) authentication.getPrincipal();
-        int registerNumber = trainingMapper.registerTraining(userDetails.getUserId(),
-        													 request.getTrainingTime(),
-        													 request.getTrainingPlace(),
-        													 request.getTrainingComments());
-        if (registerNumber == 0) {
-            throw new DatabaseOperationException("練習日誌を登録できませんでした", new Exception());
-        }
-        return registerNumber;
+	    try {
+	    	int registerNumber = trainingMapper.registerTraining(userDetails.getUserId(),
+					 request.getTrainingTime(),
+					 request.getTrainingPlace(),
+					 request.getTrainingComments());
+			if (registerNumber == 0) {
+			throw new DatabaseOperationException("練習日誌を登録できませんでした", new Exception());
+			}
+			return registerNumber;
+	    }catch (DataIntegrityViolationException e) {
+	         throw new IllegalStateException("この日付の練習日誌は既に登録されています。");
+	    }
     }
 }

--- a/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/impl/TrainingServiceImpl.java
+++ b/src/main/java/io/github/Toku2001/trackandfieldapp/service/training/impl/TrainingServiceImpl.java
@@ -33,6 +33,7 @@ public class TrainingServiceImpl implements TrainingService{
             throw new DatabaseOperationException("想定のデータが取得できていません。", new Exception());
         }
         TrainingResponse trainingResonse = new TrainingResponse();
+        trainingResonse.setTrainingId(training_Info.getTraining_Id());
         trainingResonse.setTrainingTime(training_Info.getTraining_Time());
         trainingResonse.setTrainingPlace(training_Info.getTraining_Place());
         trainingResonse.setTrainingComments(training_Info.getTraining_Comments());

--- a/src/main/resources/mapper/CompetitionMapper.xml
+++ b/src/main/resources/mapper/CompetitionMapper.xml
@@ -24,7 +24,7 @@
 
   <!-- 日付で大会情報を取得 -->
   <select id="getCompetitionByDate" resultType="io.github.Toku2001.trackandfieldapp.entity.Competition_Info">
-    SELECT competition_name, competition_place, competition_time, competition_comments
+    SELECT competition_id, competition_name, competition_place, competition_time, competition_comments
     FROM competitions
     WHERE user_id = #{userId}
       AND competition_time = #{competitionTime}
@@ -43,6 +43,7 @@
     SELECT *
 	FROM competitions
 	WHERE competition_time::date >= CURRENT_DATE
+	AND user_id = #{userId}
 	ORDER BY competition_time ASC
 	LIMIT 1;
   </select>
@@ -53,9 +54,10 @@
     SET
       competition_name = #{competitionName},
       competition_place = #{competitionPlace},
-      competition_comments = #{competitionComments}
+      competition_comments = #{competitionComments},
+      competition_time = #{competitionTime}
     WHERE user_id = #{userId}
-      AND competition_time = #{competitionTime}
+      AND competition_id = #{competitionId}
   </update>
 
   <!-- 大会情報の削除 -->

--- a/src/main/resources/mapper/JumpMapper.xml
+++ b/src/main/resources/mapper/JumpMapper.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="io.github.Toku2001.trackandfieldapp.repository.JumpMapper">
+
+  <!-- 跳躍記録の登録 -->
+  <insert id="registerJump" parameterType="map">
+    INSERT INTO jump_events (
+      user_id,
+      event_code,
+      jump_distance,
+      approach_steps,
+      pole_length,
+      pole_stiffness,
+      record_type,
+      jump_date
+    ) VALUES (
+      #{userId},
+      #{event.event},
+      #{event.distance},
+      #{event.approach},
+      #{event.poleFeat},
+      #{event.polePond},
+      #{event.recordType},
+      #{event.jumpDate}
+    )
+  </insert>
+  
+  <select id="getJumpRecord" resultType="io.github.Toku2001.trackandfieldapp.entity.Jump_Events">
+    SELECT * FROM jump_events
+    WHERE user_id = #{userId}
+      AND jump_date = #{date}
+  </select>
+  
+  <!-- 跳躍情報の更新 -->
+  <update id="changeJump">
+    UPDATE jump_events
+    SET
+      user_id = #{userId},
+      event_code = #{event.event},
+      jump_distance = #{event.distance},
+      approach_steps = #{event.approach},
+      pole_length = #{event.poleFeat},
+      pole_stiffness = #{event.polePond},
+      record_type = #{event.recordType},
+      jump_date = #{event.jumpDate}
+    WHERE user_id = #{userId}
+      AND jump_event_id = #{event.jumpEventId}
+  </update>
+  
+  <!-- 1件削除 -->
+  <delete id="deleteById" parameterType="long">
+    DELETE FROM jump_events
+    WHERE jump_event_id = #{jumpEventId}
+  </delete>
+  
+  <!-- 指定日付の全件削除 -->
+  <delete id="deleteAllByDate" parameterType="java.time.LocalDate">
+    DELETE FROM jump_events
+    WHERE jump_date = #{jumpDate}
+  </delete>
+  
+  <!-- 自己ベスト取得 -->
+  <select id="getPersonalBest" resultType="io.github.Toku2001.trackandfieldapp.entity.Jump_Events">
+  SELECT DISTINCT ON (event_code)
+    jump_event_id,
+    user_id,
+    event_code,
+    jump_distance,
+    approach_steps,
+    pole_length,
+    pole_stiffness,
+    record_type,
+    jump_date,
+    insert_date,
+    update_date
+  FROM jump_events
+  WHERE user_id = #{userId}
+  ORDER BY event_code, jump_distance DESC, jump_date ASC
+</select>
+
+</mapper>

--- a/src/main/resources/mapper/TrainingMapper.xml
+++ b/src/main/resources/mapper/TrainingMapper.xml
@@ -6,29 +6,29 @@
 	VALUES (#{userId}, #{trainingTime}, #{trainingPlace}, #{trainingComments})
 	</insert>
 
-<!--<select id="getTrainingByDate" resultType="io.github.Toku2001.trackandfieldapp.entity.Training_Info">-->
-<!--	SELECT training_time, training_place, training_comments FROM training_info -->
-<!--	WHERE training_time = #{trainingTime}-->
-<!--	AND user_id = #{userId}-->
-<!--	</select>-->
+<select id="getTrainingByDate" resultType="io.github.Toku2001.trackandfieldapp.entity.Training_Info">
+	SELECT training_id, training_time, training_place, training_comments FROM training_info 
+	WHERE training_time = #{trainingTime}
+	AND user_id = #{userId}
+	</select>
 
 <!--<select id="getTrainingByUserId" resultType="io.github.Toku2001.trackandfieldapp.entity.Training_Info">-->
 <!--	SELECT training_time, training_place, training_comments FROM training_info -->
 <!--	WHERE user_id = #{userId}-->
 <!--	</select>-->
 	
-<!--<update id="changeTraining" parameterType="io.github.Toku2001.trackandfieldapp.entity.Training_Info">-->
-<!--	UPDATE training_info -->
-<!--	SET training_place = #{trainingPlace}, training_comments = #{trainingComments}-->
-<!--	WHERE user_id = #{userId}-->
-<!--	AND training_time = #{trainingTime}-->
-<!--	</update>-->
+<update id="changeTraining" parameterType="io.github.Toku2001.trackandfieldapp.entity.Training_Info">
+	UPDATE training_info 
+	SET training_place = #{trainingPlace}, training_comments = #{trainingComments}, training_time = #{trainingTime}
+	WHERE user_id = #{userId}
+	AND training_id = #{trainingId}
+	</update>
 	
-<!--<delete id="deleteTraining" parameterType="io.github.Toku2001.trackandfieldapp.entity.Training_Info">-->
-<!--	DELETE FROM training_info -->
-<!--	WHERE user_id = #{userId}-->
-<!--	AND training_time = #{trainingTime}-->
-<!--	</delete>-->
+<delete id="deleteTraining" parameterType="io.github.Toku2001.trackandfieldapp.entity.Training_Info">-->
+	DELETE FROM training_info
+	WHERE user_id = #{userId}
+	AND training_time = #{trainingTime}
+	</delete>
 	
 <!--<select id="getTrainings" resultType="io.github.Toku2001.trackandfieldapp.entity.Training_Info">-->
 <!--	SELECT * FROM user_info -->

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/JumpTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/JumpTest.java
@@ -1,0 +1,222 @@
+package io.github.Toku2001.trackandfieldapp.unittest;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import io.github.Toku2001.trackandfieldapp.dto.competition.CompetitionResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.PersonalBestResponse;
+import io.github.Toku2001.trackandfieldapp.service.competition.CompetitionService;
+import io.github.Toku2001.trackandfieldapp.service.jump.ChangeJumpService;
+import io.github.Toku2001.trackandfieldapp.service.jump.DeleteJumpService;
+import io.github.Toku2001.trackandfieldapp.service.jump.JumpService;
+import io.github.Toku2001.trackandfieldapp.service.jump.RegisterJumpService;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@WithMockUser(username = "testuser", roles = {"USER"})
+public class JumpTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private RegisterJumpService registerJumpService;
+
+	@MockBean
+	private DeleteJumpService deleteJumpService;
+
+	@MockBean
+	private ChangeJumpService changeJumpService;
+
+	@MockBean
+	private CompetitionService competitionService;
+
+	@MockBean
+	private JumpService jumpService;
+
+	// --- /register-jump-records ---
+	@Test
+	void registerJumpRecords_Success() throws Exception {
+		String json = """
+		[
+			{
+				"eventCode": "PV",
+				"jumpDistance": 5.10,
+				"approachSteps": 16,
+				"poleLength": 4.85,
+				"poleStiffness": 18.2,
+				"recordType": "official",
+				"jumpDate": "2025-07-27"
+			}
+		]
+		""";
+		Mockito.doNothing().when(registerJumpService).registerJump(anyList());
+
+		mockMvc.perform(post("/api/register-jump-records")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.result").value(1));
+	}
+
+	@Test
+	void registerJumpRecords_EmptyList() throws Exception {
+		String json = "[]";
+		Mockito.doNothing().when(registerJumpService).registerJump(anyList());
+
+		mockMvc.perform(post("/api/register-jump-records")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.result").value(1));
+	}
+
+	// --- /delete-jump-record ---
+	@Test
+	void deleteJumpRecord_Success() throws Exception {
+		when(deleteJumpService.deleteById(eq(1L))).thenReturn(1);
+
+		mockMvc.perform(delete("/api/delete-jump-record")
+				.param("jumpEventId", "1"))
+			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void deleteJumpRecord_NotFound() throws Exception {
+		when(deleteJumpService.deleteById(eq(999L))).thenReturn(0);
+
+		mockMvc.perform(delete("/api/delete-jump-record")
+				.param("jumpEventId", "999"))
+			.andExpect(status().isNotFound());
+	}
+
+	// --- /delete-jump-records-by-date ---
+	@Test
+	void deleteJumpRecordsByDate_Success() throws Exception {
+		when(deleteJumpService.deleteAllByDate(eq("2025-07-27"))).thenReturn(2);
+
+		mockMvc.perform(delete("/api/delete-jump-records-by-date")
+				.param("jumpDate", "2025-07-27"))
+			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void deleteJumpRecordsByDate_NotFound() throws Exception {
+		when(deleteJumpService.deleteAllByDate(eq("2025-07-27"))).thenReturn(0);
+
+		mockMvc.perform(delete("/api/delete-jump-records-by-date")
+				.param("jumpDate", "2025-07-27"))
+			.andExpect(status().isNotFound());
+	}
+
+	// --- /change-jump-records ---
+	@Test
+	void changeJumpRecords_Success() throws Exception {
+		String json = """
+		[
+			{
+				"jumpEventId": 1,
+				"eventCode": "PV",
+				"jumpDistance": 5.20,
+				"approachSteps": 16,
+				"poleLength": 4.85,
+				"poleStiffness": 18.2,
+				"recordType": "official",
+				"jumpDate": "2025-07-27"
+			}
+		]
+		""";
+		when(changeJumpService.changeJump(anyList())).thenReturn(1);
+
+		mockMvc.perform(put("/api/change-jump-records")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isOk())
+			.andExpect(content().string("1"));
+	}
+
+	@Test
+	void changeJumpRecords_Failure() throws Exception {
+		String json = """
+		[
+			{
+				"jumpEventId": 1,
+				"eventCode": "PV",
+				"jumpDistance": 5.20,
+				"approachSteps": 16,
+				"poleLength": 4.85,
+				"poleStiffness": 18.2,
+				"recordType": "official",
+				"jumpDate": "2025-07-27"
+			}
+		]
+		""";
+		when(changeJumpService.changeJump(anyList())).thenReturn(0);
+
+		mockMvc.perform(put("/api/change-jump-records")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(json))
+			.andExpect(status().isBadRequest());
+	}
+
+	// --- /get-competition-upcoming ---
+	@Test
+	void getCompetitionUpcoming_Success() throws Exception {
+		CompetitionResponse response = new CompetitionResponse();
+		response.setCompetitionTime(LocalDate.of(2025, 8, 1));
+		response.setCompetitionName("Next Meet");
+		response.setCompetitionPlace("競技場");
+		when(competitionService.getNextCompetition()).thenReturn(response);
+
+		mockMvc.perform(get("/api/get-competition-upcoming"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.competitionName").value("Next Meet"))
+			.andExpect(jsonPath("$.competitionPlace").value("競技場"))
+			.andExpect(jsonPath("$.competitionTime").value("2025-08-01"));
+	}
+
+	@Test
+	void getCompetitionUpcoming_Failure() throws Exception {
+		when(competitionService.getNextCompetition()).thenReturn(null);
+
+		mockMvc.perform(get("/api/get-competition-upcoming"))
+			.andExpect(status().isInternalServerError());
+	}
+
+	// --- /get-personal-best ---
+	@Test
+	void getPersonalBest_Success() throws Exception {
+		PersonalBestResponse pb = new PersonalBestResponse("PV", 5.30, "2025-07-27");
+		when(jumpService.getPersonalBest()).thenReturn(List.of(pb));
+
+		mockMvc.perform(get("/api/get-personal-best"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].event").value("PV"))
+			.andExpect(jsonPath("$[0].distance").value(5.30))
+			.andExpect(jsonPath("$[0].jumpDate").value("2025-07-27"));
+	}
+
+	@Test
+	void getPersonalBest_Failure() throws Exception {
+		when(jumpService.getPersonalBest()).thenReturn(null);
+
+		mockMvc.perform(get("/api/get-personal-best"))
+			.andExpect(status().isInternalServerError());
+	}
+}

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/TrainingTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/TrainingTest.java
@@ -23,7 +23,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import io.github.Toku2001.trackandfieldapp.dto.training.DeleteTrainingRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.TrainingResponse;
 import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
 import io.github.Toku2001.trackandfieldapp.exception.DatabaseOperationException;
@@ -193,10 +192,8 @@ public class TrainingTest {
     
     @Test
     void delete_Success() throws Exception {
-        LocalDate date = LocalDate.of(2025, 7, 27);
-        DeleteTrainingRequest deleteTrainingRequest = new DeleteTrainingRequest(date);
 
-        when(deleteTrainingService.deleteTraining(deleteTrainingRequest))
+        when(deleteTrainingService.deleteTraining(LocalDate.of(2025, 7, 27)))
             .thenReturn(1); // 削除成功
 
         // JSON文字列を正しく構築
@@ -236,7 +233,7 @@ public class TrainingTest {
         String updateTrainingComments = "練習日誌を変更";
 //        ChangeTrainingRequest changeTrainingRequest = new ChangeTrainingRequest(date, updateTrainingPlace, updateTrainingComments);
 
-        when(trainingMapper.changeTraining(anyLong(), eq(date), eq(updateTrainingPlace), eq(updateTrainingComments)))
+        when(trainingMapper.changeTraining(anyLong(), anyInt(), eq(date), eq(updateTrainingPlace), eq(updateTrainingComments)))
             .thenReturn(1); // 削除成功
 
         // JSON文字列を正しく構築

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/TrainingTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/TrainingTest.java
@@ -196,16 +196,9 @@ public class TrainingTest {
         when(deleteTrainingService.deleteTraining(LocalDate.of(2025, 7, 27)))
             .thenReturn(1); // 削除成功
 
-        // JSON文字列を正しく構築
-        String json = """
-        {
-            "trainingDate": "2025-07-27"
-        }
-        """;
-
         mockMvc.perform(delete("/api/delete-training")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
+                .param("trainingDate", "2025-07-27")
+                .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.deleteDate").value("2025-07-27"))
             .andExpect(jsonPath("$.deleteNumber").value(1));
@@ -213,17 +206,12 @@ public class TrainingTest {
 
     @Test
     void delete_Failer() throws Exception {
-        String json = """
-        {
-            "trainingDate": ""
-        }
-        """;
+        when(deleteTrainingService.deleteTraining(LocalDate.of(2025, 7, 27))).thenReturn(0);
 
         mockMvc.perform(delete("/api/delete-training")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.error").value("削除したい練習日誌の日付が正しくリクエストされていません"));
+                .param("competitionDate", "")
+                .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
     
     @Test

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionControllerTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionControllerTest.java
@@ -240,22 +240,17 @@ public class CompetitionControllerTest {
             .andExpect(status().isOk())
             .andExpect(content().string("1"));
     }
-    
-    @Test
-    void deleteCompetition_invalid_shouldReturn400() throws Exception {
-        when(deleteCompetitionService.deleteCompetition(any())).thenReturn(0); // 失敗
 
-        String json = """
-            {
-                "competitionDate": "2025-07-28"
-            }
-            """;
+    @Test
+    void deleteCompetition_shouldReturn401_whenServiceReturns0() throws Exception {
+        // サービスが0を返すようにモック
+        when(deleteCompetitionService.deleteCompetition(any(LocalDate.class)))
+            .thenReturn(0);
 
         mockMvc.perform(delete("/api/delete-competition")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
-            .andExpect(status().isBadRequest())
-            .andExpect(status().reason("Required parameter 'competitionDate' is not present."));
+                .param("competitionDate", "2025-07-28"))
+            .andExpect(status().isUnauthorized()) // 401
+            .andExpect(status().reason("Invalid credentials"));
     }
     
     //GET

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionControllerTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionControllerTest.java
@@ -266,12 +266,13 @@ public class CompetitionControllerTest {
     //GET
     @Test
     void getCompetitionByDate_valid_shouldReturn200() throws Exception {
-        CompetitionResponse response = new CompetitionResponse("大会", "競技場", LocalDate.of(2025, 7, 28), "コメント");
+        CompetitionResponse response = new CompetitionResponse(1, "大会", "競技場", LocalDate.of(2025, 7, 28), "コメント");
         when(competitionService.getCompetitionByDate(any())).thenReturn(response);
 
         mockMvc.perform(get("/api/get-competition")
                 .param("competitionDate", "2025-07-28"))
             .andExpect(status().isOk())
+            .andExpect(jsonPath("$.competitionId").value(1))
             .andExpect(jsonPath("$.competitionName").value("大会"))
             .andExpect(jsonPath("$.competitionPlace").value("競技場"))
             .andExpect(jsonPath("$.competitionTime").value("2025-07-28"))
@@ -291,12 +292,13 @@ public class CompetitionControllerTest {
     //次の大会情報を取得
     @Test
     void getNextCompetition_valid_shouldReturn200() throws Exception {
-        CompetitionResponse response = new CompetitionResponse("大会", "競技場", LocalDate.of(2025, 7, 28), "コメント");
+        CompetitionResponse response = new CompetitionResponse(1, "大会", "競技場", LocalDate.of(2025, 7, 28), "コメント");
         when(competitionService.getNextCompetition()).thenReturn(response);
 
         mockMvc.perform(get("/api/get-competition-upcoming"))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.competitionName").value("大会"))
+            .andExpect(jsonPath("$.competitionId").value(1))
             .andExpect(jsonPath("$.competitionPlace").value("競技場"))
             .andExpect(jsonPath("$.competitionTime").value("2025-07-28"))
             .andExpect(jsonPath("$.competitionComments").value("コメント"));

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionControllerTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionControllerTest.java
@@ -184,7 +184,7 @@ public class CompetitionControllerTest {
         
         RegisterCompetitionRequest registerCompetitionRequest = new RegisterCompetitionRequest(competitionName, competitionPlace, competitionTime, competitionComments);
 
-        when(competitionMapper.registerCompetition(anyLong(), any(), any(), any(LocalDate.class), any()))
+        when(registerCompetitionService.registerCompetition(registerCompetitionRequest))
                 .thenReturn(1);
 
         int result = registerCompetitionService.registerCompetition(registerCompetitionRequest);

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionControllerTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import io.github.Toku2001.trackandfieldapp.dto.competition.CompetitionResponse;
 import io.github.Toku2001.trackandfieldapp.dto.competition.RegisterCompetitionRequest;
 import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
+import io.github.Toku2001.trackandfieldapp.exception.DatabaseOperationException;
 import io.github.Toku2001.trackandfieldapp.repository.CompetitionMapper;
 import io.github.Toku2001.trackandfieldapp.service.competition.ChangeCompetitionService;
 import io.github.Toku2001.trackandfieldapp.service.competition.CompetitionService;
@@ -231,23 +232,17 @@ public class CompetitionControllerTest {
     //DELETE
     @Test
     void deleteCompetition_validInput_shouldReturn200() throws Exception {
-        when(deleteCompetitionService.deleteCompetition(any())).thenReturn(1);
-
-        String json = """
-            {
-                "competitionDate": "2025-07-28"
-            }
-            """;
+        when(deleteCompetitionService.deleteCompetition(LocalDate.of(2025, 7, 27))).thenReturn(1);
 
         mockMvc.perform(delete("/api/delete-competition")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(json))
+                .param("competitionDate", "2025-07-27")
+                .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string("1"));
     }
     
     @Test
-    void deleteCompetition_invalid_shouldReturn401() throws Exception {
+    void deleteCompetition_invalid_shouldReturn400() throws Exception {
         when(deleteCompetitionService.deleteCompetition(any())).thenReturn(0); // 失敗
 
         String json = """
@@ -259,8 +254,8 @@ public class CompetitionControllerTest {
         mockMvc.perform(delete("/api/delete-competition")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
-            .andExpect(status().isUnauthorized())
-            .andExpect(status().reason("Invalid credentials"));
+            .andExpect(status().isBadRequest())
+            .andExpect(status().reason("Required parameter 'competitionDate' is not present."));
     }
     
     //GET

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionServiceImplTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/competition/CompetitionServiceImplTest.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.github.Toku2001.trackandfieldapp.dto.competition.ChangeCompetitionRequest;
 import io.github.Toku2001.trackandfieldapp.dto.competition.CompetitionResponse;
-import io.github.Toku2001.trackandfieldapp.dto.competition.DeleteCompetitionRequest;
 import io.github.Toku2001.trackandfieldapp.dto.competition.RegisterCompetitionRequest;
 import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
 import io.github.Toku2001.trackandfieldapp.entity.Competition_Info;
@@ -66,6 +65,7 @@ class CompetitionServiceImplTest {
     
     private ChangeCompetitionRequest changeValidRequest() {
         return new ChangeCompetitionRequest(
+        		1,
             "大会名",
             "競技場",
             LocalDate.of(2025, 7, 27),
@@ -156,13 +156,12 @@ class CompetitionServiceImplTest {
     void deleteCompetition_validRequest_shouldReturnRegisterNumber() {
         setAuthentication(new UserDetailsForToken(1L, "testuser", List.of()));
 
-        DeleteCompetitionRequest deleteRequest = new DeleteCompetitionRequest(LocalDate.of(2025, 7, 27));
         when(mapper.deleteCompetition(
             anyLong(),
             any(LocalDate.class)))
         .thenReturn(1);
 
-        int deleteResult = deleteService.deleteCompetition(deleteRequest);
+        int deleteResult = deleteService.deleteCompetition(LocalDate.of(2025, 7, 27));
         assertEquals(1, deleteResult);
     }
     
@@ -170,13 +169,12 @@ class CompetitionServiceImplTest {
     void deleteCompetition_mapperReturnsZero_shouldThrowDatabaseOperationException() {
         setAuthentication(new UserDetailsForToken(1L, "testuser", List.of()));
 
-        DeleteCompetitionRequest deleteRequest = new DeleteCompetitionRequest(LocalDate.of(2025, 7, 27));
         when(mapper.deleteCompetition(
             anyLong(),
             any(LocalDate.class)))
         .thenReturn(0);
 
-        Exception ex = assertThrows(DatabaseOperationException.class, () -> deleteService.deleteCompetition(deleteRequest));
+        Exception ex = assertThrows(DatabaseOperationException.class, () -> deleteService.deleteCompetition(LocalDate.of(2025, 7, 27)));
         assertEquals("正しく競技会情報が削除されませんでした", ex.getMessage());
     }
     
@@ -188,6 +186,7 @@ class CompetitionServiceImplTest {
         ChangeCompetitionRequest changeRequest = changeValidRequest();
         when(mapper.changeCompetition(
                 anyLong(),
+                anyInt(),
                 anyString(),
                 anyString(),
                 any(LocalDate.class),
@@ -205,6 +204,7 @@ class CompetitionServiceImplTest {
         ChangeCompetitionRequest changeRequest = changeValidRequest();
         when(mapper.changeCompetition(
                 anyLong(),
+                anyInt(),
                 anyString(),
                 anyString(),
                 any(LocalDate.class),
@@ -222,8 +222,7 @@ class CompetitionServiceImplTest {
         
         // モックが返すレスポンスを定義
         Competition_Info mockResponse = new Competition_Info();
-        mockResponse.setCompetition_Id(1L);
-        mockResponse.setUser_Id(1L);
+        mockResponse.setCompetition_Id(0);
         mockResponse.setCompetition_Name("大会名");
         mockResponse.setCompetition_Place("場所");
         mockResponse.setCompetition_Time(LocalDate.of(2025, 7, 27));
@@ -250,8 +249,7 @@ class CompetitionServiceImplTest {
         
         // モックが返すレスポンスを定義
         Competition_Info mockResponse = new Competition_Info();
-        mockResponse.setCompetition_Id(1L);
-        mockResponse.setUser_Id(1L);
+        mockResponse.setCompetition_Id(1);
         mockResponse.setCompetition_Name("大会名");
         mockResponse.setCompetition_Place("場所");
         mockResponse.setCompetition_Time(LocalDate.of(2025, 7, 27));
@@ -279,8 +277,7 @@ class CompetitionServiceImplTest {
         
         // モックが返すレスポンスを定義
         Competition_Info mockNextResponse = new Competition_Info();
-        mockNextResponse.setCompetition_Id(1L);
-        mockNextResponse.setUser_Id(1L);
+        mockNextResponse.setCompetition_Id(1);
         mockNextResponse.setCompetition_Name("大会名");
         mockNextResponse.setCompetition_Place("場所");
         mockNextResponse.setCompetition_Time(LocalDate.of(2025, 7, 27));
@@ -291,8 +288,8 @@ class CompetitionServiceImplTest {
         competitionNextResponse.setCompetitionPlace("場所");
         competitionNextResponse.setCompetitionTime(LocalDate.of(2025, 7, 27));
 
-        when(mapper.getNextCompetition())
-            .thenReturn(mockNextResponse);
+       when(mapper.getNextCompetition(1L))
+           .thenReturn(mockNextResponse);
 
         CompetitionResponse getResult = competitionService.getNextCompetition();
         assertEquals(competitionNextResponse, getResult);
@@ -304,8 +301,7 @@ class CompetitionServiceImplTest {
         
         // モックが返すレスポンスを定義
         Competition_Info mockResponse = new Competition_Info();
-        mockResponse.setCompetition_Id(1L);
-        mockResponse.setUser_Id(1L);
+        mockResponse.setCompetition_Id(1);
         mockResponse.setCompetition_Name("大会名");
         mockResponse.setCompetition_Place("場所");
         mockResponse.setCompetition_Time(LocalDate.of(2025, 7, 27));
@@ -317,8 +313,8 @@ class CompetitionServiceImplTest {
         competitionResponse.setCompetitionTime(LocalDate.of(2025, 7, 27));
         competitionResponse.setCompetitionComments("コメント");
 
-        when(mapper.getNextCompetition())
-        .thenReturn(null);
+       when(mapper.getNextCompetition(1L))
+       .thenReturn(null);
 
         Exception ex = assertThrows(DatabaseOperationException.class, () -> competitionService.getNextCompetition());
         assertEquals("想定のデータが取得できていません。", ex.getMessage());

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpServiceLayerTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpServiceLayerTest.java
@@ -65,7 +65,9 @@ class JumpServiceLayerTest {
     @Test
     void changeJump_Success() {
         ChangeJumpRequest req = new ChangeJumpRequest();
-        doNothing().when(jumpMapper).changeJump(eq(1L), any(ChangeJumpRequest.class));
+
+        // 戻り値ありメソッドなので、doNothing()ではなくwhen().thenReturn()を使う
+        when(jumpMapper.changeJump(eq(1L), any(ChangeJumpRequest.class))).thenReturn(1);
 
         int result = changeJumpService.changeJump(List.of(req));
 

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpServiceLayerTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpServiceLayerTest.java
@@ -85,6 +85,24 @@ class JumpServiceLayerTest {
     }
 
     @Test
+	void changeJump_notAllUpdatesSuccessful_shouldReturn0() {
+		// 2件の更新リクエスト
+		ChangeJumpRequest req1 = new ChangeJumpRequest();
+		ChangeJumpRequest req2 = new ChangeJumpRequest();
+		List<ChangeJumpRequest> requests = List.of(req1, req2);
+
+		// jumpMapper.changeJump が1件目は1件更新成功、2件目は0件（失敗）を返す
+		when(jumpMapper.changeJump(anyLong(), any(ChangeJumpRequest.class)))
+			.thenReturn(1)
+			.thenReturn(0);
+
+		int result = changeJumpService.changeJump(requests);
+
+		// 更新件数がリクエスト件数に満たないため0が返る
+		assertEquals(0, result);
+	}
+
+    @Test
     void deleteById_Success() {
         when(jumpMapper.deleteById(10L)).thenReturn(1);
 

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpServiceLayerTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpServiceLayerTest.java
@@ -1,0 +1,155 @@
+package io.github.Toku2001.trackandfieldapp.unittest.jump;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import io.github.Toku2001.trackandfieldapp.dto.jump.ChangeJumpRequest;
+import io.github.Toku2001.trackandfieldapp.dto.jump.JumpResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.PersonalBestResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.RegisterJumpRequest;
+import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
+import io.github.Toku2001.trackandfieldapp.entity.Jump_Events;
+import io.github.Toku2001.trackandfieldapp.exception.DatabaseOperationException;
+import io.github.Toku2001.trackandfieldapp.repository.JumpMapper;
+import io.github.Toku2001.trackandfieldapp.service.jump.impl.ChangeJumpServiceImpl;
+import io.github.Toku2001.trackandfieldapp.service.jump.impl.DeleteJumpServiceImpl;
+import io.github.Toku2001.trackandfieldapp.service.jump.impl.JumpServiceImpl;
+import io.github.Toku2001.trackandfieldapp.service.jump.impl.RegisterJumpServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+class JumpServiceLayerTest {
+
+    @Mock
+    private JumpMapper jumpMapper;
+
+    @InjectMocks
+    private ChangeJumpServiceImpl changeJumpService;
+
+    @InjectMocks
+    private DeleteJumpServiceImpl deleteJumpService;
+
+    @InjectMocks
+    private JumpServiceImpl jumpService;
+
+    @InjectMocks
+    private RegisterJumpServiceImpl registerJumpService;
+
+    @BeforeEach
+    void setUp() {
+        UserDetailsForToken userDetails = new UserDetailsForToken(
+            1L,
+            "testuser",
+            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    void changeJump_Success() {
+        ChangeJumpRequest req = new ChangeJumpRequest();
+        doNothing().when(jumpMapper).changeJump(eq(1L), any(ChangeJumpRequest.class));
+
+        int result = changeJumpService.changeJump(List.of(req));
+
+        assertEquals(1, result);
+        verify(jumpMapper, times(1)).changeJump(eq(1L), any(ChangeJumpRequest.class));
+    }
+
+    @Test
+    void changeJump_Failure_NoRecordsChanged() {
+        // changeJumpRecordNumber < size の場合は 0 を返す
+        ChangeJumpRequest req = new ChangeJumpRequest();
+        doThrow(new DatabaseOperationException("err", new Exception()))
+                .when(jumpMapper).changeJump(eq(1L), any(ChangeJumpRequest.class));
+
+        assertThrows(DatabaseOperationException.class,
+                () -> changeJumpService.changeJump(List.of(req)));
+    }
+
+    @Test
+    void deleteById_Success() {
+        when(jumpMapper.deleteById(10L)).thenReturn(1);
+
+        int result = deleteJumpService.deleteById(10L);
+
+        assertEquals(1, result);
+        verify(jumpMapper).deleteById(10L);
+    }
+
+    @Test
+    void deleteAllByDate_Success() {
+        LocalDate date = LocalDate.of(2025, 8, 1);
+        when(jumpMapper.deleteAllByDate(date)).thenReturn(2);
+
+        int result = deleteJumpService.deleteAllByDate("2025-08-01");
+
+        assertEquals(2, result);
+        verify(jumpMapper).deleteAllByDate(date);
+    }
+
+    @Test
+    void getJumpRecords_Success() {
+        Jump_Events event = new Jump_Events();
+        event.setJump_event_id(1L);
+        event.setEvent_code("PV");
+        event.setJump_distance(5.10);
+        event.setApproach_steps(16);
+        event.setPole_length("4.85");
+        event.setPole_stiffness("18.2");
+        event.setRecord_type("official");
+        event.setJump_date(LocalDate.of(2025, 7, 27));
+
+        when(jumpMapper.getJumpRecord(1L, LocalDate.of(2025, 7, 27)))
+                .thenReturn(List.of(event));
+
+        List<JumpResponse> result = jumpService.getJumpRecords(LocalDate.of(2025, 7, 27));
+
+        assertEquals(1, result.size());
+        assertEquals("PV", result.get(0).getEvent());
+        assertEquals("2025-07-27", result.get(0).getJumpDate());
+    }
+
+    @Test
+    void getPersonalBest_Success() {
+        Jump_Events event = new Jump_Events();
+        event.setEvent_code("PV");
+        event.setJump_distance(5.30);
+        event.setJump_date(LocalDate.of(2025, 7, 27));
+
+        when(jumpMapper.getPersonalBest(1L)).thenReturn(List.of(event));
+
+        List<PersonalBestResponse> result = jumpService.getPersonalBest();
+
+        assertEquals(1, result.size());
+        assertEquals("PV", result.get(0).getEvent());
+    }
+
+    @Test
+    void registerJump_Success() {
+        RegisterJumpRequest req = new RegisterJumpRequest();
+        
+        when(jumpMapper.registerJump(eq(1L), any(RegisterJumpRequest.class))).thenReturn(1);
+
+        registerJumpService.registerJump(List.of(req));
+
+        verify(jumpMapper, times(1)).registerJump(eq(1L), any(RegisterJumpRequest.class));
+    }
+}

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpTest.java
@@ -1,5 +1,6 @@
 package io.github.Toku2001.trackandfieldapp.unittest.jump;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -15,12 +16,16 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.github.Toku2001.trackandfieldapp.dto.competition.CompetitionResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.ChangeJumpRequest;
 import io.github.Toku2001.trackandfieldapp.dto.jump.JumpResponse;
 import io.github.Toku2001.trackandfieldapp.dto.jump.PersonalBestResponse;
+import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
 import io.github.Toku2001.trackandfieldapp.service.competition.CompetitionService;
 import io.github.Toku2001.trackandfieldapp.service.jump.ChangeJumpService;
 import io.github.Toku2001.trackandfieldapp.service.jump.DeleteJumpService;

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpTest.java
@@ -1,4 +1,4 @@
-package io.github.Toku2001.trackandfieldapp.unittest;
+package io.github.Toku2001.trackandfieldapp.unittest.jump;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/jump/JumpTest.java
@@ -19,6 +19,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import io.github.Toku2001.trackandfieldapp.dto.competition.CompetitionResponse;
+import io.github.Toku2001.trackandfieldapp.dto.jump.JumpResponse;
 import io.github.Toku2001.trackandfieldapp.dto.jump.PersonalBestResponse;
 import io.github.Toku2001.trackandfieldapp.service.competition.CompetitionService;
 import io.github.Toku2001.trackandfieldapp.service.jump.ChangeJumpService;
@@ -218,5 +219,24 @@ public class JumpTest {
 
 		mockMvc.perform(get("/api/get-personal-best"))
 			.andExpect(status().isInternalServerError());
+	}
+
+	@Test
+	void getJumpRecords() throws Exception{
+		JumpResponse jumpResponse = new JumpResponse(1L, "PV", 5.30, 12, "4.6", "150", "Official", "2025-07-27");
+		LocalDate jumpDate = LocalDate.of(2025, 7, 27);
+		when(jumpService.getJumpRecords(jumpDate)).thenReturn(List.of(jumpResponse));
+
+		mockMvc.perform(get("/api/get-jump-records")
+				.param("jumpDate", "2025-07-27"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$[0].jumpEventId").value(1L))
+			.andExpect(jsonPath("$[0].event").value("PV"))
+			.andExpect(jsonPath("$[0].distance").value(5.30))
+			.andExpect(jsonPath("$[0].approach").value(12))
+			.andExpect(jsonPath("$[0].poleFeat").value("4.6"))
+			.andExpect(jsonPath("$[0].polePond").value("150"))
+			.andExpect(jsonPath("$[0].recordType").value("Official"))
+			.andExpect(jsonPath("$[0].jumpDate").value("2025-07-27"));
 	}
 }

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingServiceTraining.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingServiceTraining.java
@@ -1,0 +1,127 @@
+package io.github.Toku2001.trackandfieldapp.unittest.training;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.mybatis.spring.annotation.MapperScan;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import io.github.Toku2001.trackandfieldapp.dto.training.TrainingResponse;
+import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
+import io.github.Toku2001.trackandfieldapp.entity.Training_Info;
+import io.github.Toku2001.trackandfieldapp.exception.DatabaseOperationException;
+import io.github.Toku2001.trackandfieldapp.repository.TrainingMapper;
+import io.github.Toku2001.trackandfieldapp.service.training.impl.ChangeTrainingServiceImpl;
+import io.github.Toku2001.trackandfieldapp.service.training.impl.DeleteTrainingServiceImpl;
+import io.github.Toku2001.trackandfieldapp.service.training.impl.RegisterTrainingServiceImpl;
+import io.github.Toku2001.trackandfieldapp.service.training.impl.TrainingServiceImpl;
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc  
+@WithMockUser(username = "testuser", roles = {"USER"})
+@Transactional
+@MapperScan("io.github.Toku2001.trackandfieldapp.repository") 
+public class TrainingServiceTraining {
+
+    @InjectMocks
+    private DeleteTrainingServiceImpl deleteTrainingService;
+	
+	@InjectMocks
+    private TrainingServiceImpl trainingService;
+	
+	@InjectMocks
+    private ChangeTrainingServiceImpl changeTrainingServiceImpl;
+	
+	@InjectMocks
+    private RegisterTrainingServiceImpl registerTrainingServiceImpl;
+
+    @Mock
+    private TrainingMapper trainingMapper;
+
+    @BeforeEach
+    void setUp() {
+        UserDetailsForToken userDetails = new UserDetailsForToken(
+            1L,
+            "testuser",
+            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    // --- DeleteTrainingServiceImpl ---
+
+    @Test
+    void deleteTraining_Success() {
+        LocalDate date = LocalDate.of(2025, 7, 27);
+        when(trainingMapper.deleteTraining(1L, date)).thenReturn(1);
+
+        int deletedCount = deleteTrainingService.deleteTraining(date);
+
+        assertEquals(1, deletedCount);
+        verify(trainingMapper).deleteTraining(1L, date);
+    }
+
+    @Test
+    void deleteTraining_Failure_ThrowsException() {
+        LocalDate date = LocalDate.of(2025, 7, 27);
+        when(trainingMapper.deleteTraining(1L, date)).thenReturn(0);
+
+        DatabaseOperationException thrown = assertThrows(DatabaseOperationException.class, () -> {
+            deleteTrainingService.deleteTraining(date);
+        });
+
+        assertTrue(thrown.getMessage().contains("正しく練習日誌が削除されませんでした"));
+        verify(trainingMapper).deleteTraining(1L, date);
+    }
+
+    // --- TrainingServiceImpl ---
+
+    @Test
+    void getTraining_Success() {
+        LocalDate date = LocalDate.of(2025, 7, 27);
+
+        Training_Info trainingInfo = new Training_Info();
+        trainingInfo.setTraining_Id(123);
+        trainingInfo.setTraining_Time(LocalDate.of(2025, 7, 27));
+        trainingInfo.setTraining_Place("競技場");
+        trainingInfo.setTraining_Comments("良い練習でした");
+
+        when(trainingMapper.getTrainingByDate(1L, date)).thenReturn(trainingInfo);
+
+        TrainingResponse response = trainingService.getTraining(date);
+
+        assertEquals(123L, response.getTrainingId());
+        assertEquals(LocalDate.of(2025, 7, 27), response.getTrainingTime());
+        assertEquals("競技場", response.getTrainingPlace());
+        assertEquals("良い練習でした", response.getTrainingComments());
+    }
+
+    @Test
+    void getTraining_Failure_ThrowsException() {
+        LocalDate date = LocalDate.of(2025, 7, 27);
+
+        when(trainingMapper.getTrainingByDate(1L, date)).thenReturn(null);
+
+        DatabaseOperationException thrown = assertThrows(DatabaseOperationException.class, () -> {
+            trainingService.getTraining(date);
+        });
+
+        assertTrue(thrown.getMessage().contains("想定のデータが取得できていません。"));
+    }
+}

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingServiceTraining.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingServiceTraining.java
@@ -199,6 +199,27 @@ public class TrainingServiceTraining {
     }
 
     @Test
+    void registerTraining_whenMapperReturnsZero_shouldThrowDatabaseOperationException() {
+        RegisterTrainingRequest request = new RegisterTrainingRequest();
+        request.setTrainingTime(LocalDate.of(2025, 7, 27));
+        request.setTrainingPlace("競技場");
+        request.setTrainingComments("コメント");
+
+        when(trainingMapper.registerTraining(
+            anyLong(),
+            any(LocalDate.class),
+            anyString(),
+            anyString()))
+            .thenReturn(0); // 0を返して登録失敗を模擬
+
+        DatabaseOperationException thrown = assertThrows(DatabaseOperationException.class, () -> {
+            registerTrainingServiceImpl.registerTraining(request);
+        });
+
+        assertEquals("練習日誌を登録できませんでした", thrown.getMessage());
+    }
+
+    @Test
     void updateTraining_shouldReturnChangeNumber() {
 
         when(trainingMapper.changeTraining(

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingServiceTraining.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingServiceTraining.java
@@ -2,11 +2,13 @@ package io.github.Toku2001.trackandfieldapp.unittest.training;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -16,12 +18,16 @@ import org.mockito.*;
 import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cglib.core.Local;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 
+import io.github.Toku2001.trackandfieldapp.dto.competition.ChangeCompetitionRequest;
+import io.github.Toku2001.trackandfieldapp.dto.training.ChangeTrainingRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.RegisterTrainingRequest;
+import io.github.Toku2001.trackandfieldapp.dto.training.TrainingRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.TrainingResponse;
 import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
 import io.github.Toku2001.trackandfieldapp.entity.Training_Info;
@@ -54,6 +60,15 @@ public class TrainingServiceTraining {
 
     @Mock
     private TrainingMapper trainingMapper;
+
+    private ChangeTrainingRequest changeTrainingRequest(){
+        ChangeTrainingRequest changeTrainingRequest = new ChangeTrainingRequest();
+        changeTrainingRequest.setTrainingId(1);
+        changeTrainingRequest.setTrainingComments("跳躍練習");
+        changeTrainingRequest.setTrainingPlace("学校");
+        changeTrainingRequest.setTrainingTime(LocalDate.of(2025, 07, 27));
+        return changeTrainingRequest;
+    }
 
     @BeforeEach
     void setUp() {
@@ -181,5 +196,37 @@ public class TrainingServiceTraining {
             eq(request.getTrainingPlace()),
             eq(request.getTrainingComments())
         );
+    }
+
+    @Test
+    void updateTraining_shouldReturnChangeNumber() {
+
+        when(trainingMapper.changeTraining(
+                anyLong(),
+                anyInt(),
+                any(LocalDate.class),
+                anyString(),
+                anyString()))
+            .thenReturn(1);
+
+        ChangeTrainingRequest changeRequest = changeTrainingRequest();
+        int changeResult = changeTrainingServiceImpl.changeTraining(changeRequest);
+        assertEquals(1, changeResult);
+    }
+
+    @Test
+    void updateTraining_ZeroChangeNumber() {
+
+        when(trainingMapper.changeTraining(
+                anyLong(),
+                anyInt(),
+                any(LocalDate.class),
+                anyString(),
+                anyString()))
+            .thenReturn(0);
+
+        ChangeTrainingRequest changeRequest = changeTrainingRequest();
+        Exception ex = assertThrows(DatabaseOperationException.class, () -> changeTrainingServiceImpl.changeTraining(changeRequest));
+        assertEquals("練習日誌の更新件数が0件です。", ex.getMessage());
     }
 }

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingTest.java
@@ -1,4 +1,4 @@
-package io.github.Toku2001.trackandfieldapp.unittest;
+package io.github.Toku2001.trackandfieldapp.unittest.training;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingTest.java
@@ -242,13 +242,15 @@ public class TrainingTest {
     }
 
     @Test
-    void delete_Failer() throws Exception {
-        when(deleteTrainingService.deleteTraining(LocalDate.of(2025, 7, 27))).thenReturn(0);
+    void deleteTraining_shouldReturn401_whenServiceReturns0() throws Exception {
+        // サービスが0を返すようにモック
+        when(deleteTrainingService.deleteTraining(any(LocalDate.class)))
+            .thenReturn(0);
 
         mockMvc.perform(delete("/api/delete-training")
-                .param("competitionDate", "")
-                .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isBadRequest());
+                .param("trainingDate", "2025-07-28"))
+            .andExpect(status().isUnauthorized()) // 401
+            .andExpect(status().reason("Invalid credentials"));
     }
     
     @Test

--- a/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingTest.java
+++ b/src/test/java/io/github/Toku2001/trackandfieldapp/unittest/training/TrainingTest.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 
+import io.github.Toku2001.trackandfieldapp.dto.training.ChangeTrainingRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.RegisterTrainingRequest;
 import io.github.Toku2001.trackandfieldapp.dto.training.TrainingResponse;
 import io.github.Toku2001.trackandfieldapp.dto.user.UserDetailsForToken;
@@ -92,9 +93,9 @@ public class TrainingTest {
             }
             """;
 
-        when(trainingMapper.registerTraining(anyLong(), any(LocalDate.class), anyString(), anyString()))
-                .thenReturn(1); // DB登録成功を模擬
-
+        when(registerTrainingService.registerTraining(any(RegisterTrainingRequest.class)))
+            .thenReturn(1);
+        
         mockMvc.perform(post("/api/register-training")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(json))
@@ -252,13 +253,8 @@ public class TrainingTest {
     
     @Test
     void update_Success() throws Exception {
-        LocalDate date = LocalDate.of(2025, 7, 27);
-        String updateTrainingPlace = "練習場所を変更";
-        String updateTrainingComments = "練習日誌を変更";
-//        ChangeTrainingRequest changeTrainingRequest = new ChangeTrainingRequest(date, updateTrainingPlace, updateTrainingComments);
-
-        when(trainingMapper.changeTraining(anyLong(), anyInt(), eq(date), eq(updateTrainingPlace), eq(updateTrainingComments)))
-            .thenReturn(1); // 削除成功
+        when(changeTrainingService.changeTraining(any(ChangeTrainingRequest.class)))
+    .thenReturn(1);
 
         // JSON文字列を正しく構築
         String json = """


### PR DESCRIPTION
# 画面作成に伴って発生したバックエンドの修正
## 以下の内容を修正・追加
・跳躍記録の登録・削除・更新・参照機能を追加
・登録された跳躍記録の中で、一番良い記録を自己ベストとして取得するAPI作成
・競技会情報・練習日誌情報を取得する際にシーケンスも取得するようにする(ユーザーが指定したデータを正確に削除・更新するため)